### PR TITLE
Switch to GPT-4, add support for multiple prompt types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,19 @@
 name: Deploy App
 
-on:
-  push:
-    branches: [ master ]
+on: [push]
 
 jobs:
-  frontend:
+  test:
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd lib && pip3 install -e .[dev] && pytest
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: test
 
     strategy:
       matrix:

--- a/lib/quizicist/__init__.py
+++ b/lib/quizicist/__init__.py
@@ -1,1 +1,2 @@
 from .completion import complete as generate_quiz
+from .prompt import PromptType

--- a/lib/quizicist/completion.py
+++ b/lib/quizicist/completion.py
@@ -5,7 +5,7 @@ import os
 from dotenv import load_dotenv
 from .consts import GPT_MODEL, MAX_CONTEXT_SIZE, ESTIMATED_QUESTION_SIZE, NUM_QUESTIONS
 from .errors import QuizicistError
-from .prompt import Prompt
+from .prompt import Prompt, PromptType
 from .postprocess import postprocess_edit_mode, postprocess_manual
 
 # set up openai
@@ -42,25 +42,27 @@ def shard_chapter(components):
     return shards
 
 
-def run_gpt3(shard, num_questions):
-    prompt = Prompt(num_questions=num_questions)\
-        .add_text(shard, newlines=0)\
-        .add_introduction()\
-        .add_template()\
-        .add_instructions()
+def run_gpt3(shard, num_questions, prompt_type):
+    prompt = Prompt(prompt_type=prompt_type, num_questions=num_questions)\
+        .add_system_prompt()\
+        .add_message(role="user", content=shard)\
+
 
     # process question until 5 well-formatted questions have been generated
     # TODO: add tally for failed generations and quit after n
     while True:
         print(f"Running completion on shard...")
-        completion = "Question:" + openai.Completion.create(
-            engine=GPT_MODEL,
-            prompt=prompt.prompt,
+        completion = openai.ChatCompletion.create(
+            model=GPT_MODEL,
+            messages=prompt.messages,            
             max_tokens=NUM_QUESTIONS * ESTIMATED_QUESTION_SIZE,
             temperature=0.8,
-        )["choices"][0]["text"]
-
-        processed = postprocess_edit_mode(completion, num_questions)
+        )
+                
+        content = completion["choices"][0]["message"]["content"]
+        
+        print("Post processing shard...")
+        processed = postprocess_edit_mode(content, prompt_type, num_questions)
 
         if processed:
             return processed
@@ -68,7 +70,7 @@ def run_gpt3(shard, num_questions):
 
 # divide quiz questions evenly by shard
 # don't allow more than five questions per shard
-def divide_questions(shards, num_questions):
+def divide_questions(shards, num_questions, prompt_type):
     # find questions per shard and remainder after division
     remainder = num_questions % len(shards)
     questions_per_shard = num_questions // len(shards)
@@ -85,16 +87,16 @@ def divide_questions(shards, num_questions):
     else:
         for index, shard in enumerate(shards):
             if index < remainder:
-                jobs.append((shard, questions_per_shard + 1))
+                jobs.append((shard, questions_per_shard + 1, prompt_type))
             elif questions_per_shard > 0:
-                jobs.append((shard, questions_per_shard))
+                jobs.append((shard, questions_per_shard, prompt_type))
 
     return jobs
 
-def complete(file_content, parser, num_questions):
+def complete(file_content, parser, num_questions, prompt_type=PromptType.MCQ):
     components = parser(file_content)
     shards = shard_chapter(components)
-    jobs = divide_questions(shards, num_questions)
+    jobs = divide_questions(shards, num_questions, prompt_type)
 
     # limit content size to three shards
     if len(shards) > 3:

--- a/lib/quizicist/completion.py
+++ b/lib/quizicist/completion.py
@@ -45,8 +45,7 @@ def shard_chapter(components):
 def run_gpt3(shard, num_questions, prompt_type):
     prompt = Prompt(prompt_type=prompt_type, num_questions=num_questions)\
         .add_system_prompt()\
-        .add_message(role="user", content=shard)\
-
+        .add_message(role="user", content=shard)
 
     # process question until 5 well-formatted questions have been generated
     # TODO: add tally for failed generations and quit after n

--- a/lib/quizicist/consts.py
+++ b/lib/quizicist/consts.py
@@ -2,7 +2,7 @@ import enum
 
 
 # gpt model to use
-GPT_MODEL = "text-davinci-003"
+GPT_MODEL = "gpt-4"
 
 # markdown element types valid at the top level
 TOP_LEVEL_COMPONENTS = [

--- a/lib/quizicist/postprocess.py
+++ b/lib/quizicist/postprocess.py
@@ -3,19 +3,31 @@ import openai
 import os
 from dotenv import load_dotenv
 from .consts import NUM_QUESTIONS, FeedbackTypes
+from .prompt import PromptType
 
 # set up openai
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_SECRET_KEY")
 
 
-EDIT_MODE_INSTRUCTION = 'Convert the list of questions into an array of JSON objects parseable by Python. Do not assign the JSON to a variable. Each object should contain keys for "question", "correct", and "incorrect".'
+EDIT_MODE_INSTRUCTION = {
+    PromptType.MCQ: """
+Convert the list of questions into an array of JSON objects parseable by Python. 
+Do not assign the JSON to a variable. 
+Each object should contain keys for "question", "correct", and "incorrect".'
+""",
+    PromptType.OPEN_ENDED: """
+Convert the list of questions into an array of JSON objects parseable by Python. 
+Do not assign the JSON to a variable. 
+Each object should contain keys for "question" and "follow-up".
+""",
+}
 
-def postprocess_edit_mode(output: str, num_questions=NUM_QUESTIONS):
+def postprocess_edit_mode(output: str, prompt_type: PromptType, num_questions=NUM_QUESTIONS):
     edited = openai.Edit.create(
         model="code-davinci-edit-001",
         input=output,
-        instruction=EDIT_MODE_INSTRUCTION,
+        instruction=EDIT_MODE_INSTRUCTION[prompt_type],
         n=1,
         temperature=0,
     )["choices"][0]["text"]

--- a/lib/quizicist/prompt.py
+++ b/lib/quizicist/prompt.py
@@ -6,21 +6,25 @@ from enum import Enum
 class PromptType(Enum):
     MCQ = 1
     OPEN_ENDED = 2
+    ADD_ANSWERS = 3
 
 PROMPTS = {
    PromptType.MCQ: """
-You are a professor creating a challenging multiple-choice quiz for your class.
-The questions you write will test your students' knowledge of concepts from the passage above.
-The questions will be very difficult, cover distinct topics, and not restate simple facts from the passage.
-The quiz contains {num_questions} multiple-choice questions.
+You are TeachGPT, a machine learning agent trained to generate educational quizzes. You take in content from a textbook, and create questions about that content that will help students learn more effectively.
+
+TeachGPT follows these rules:
+* Questions should not copy-paste definitions or code from the content. Questions should apply the content to a new situation.
+* Questions should be more than one sentence, and should provide a code snippet or hypothetical situation to ask about.
+* Questions should be multiple-choice with four options.
 
 Use the following template for each question:
-
 Question:
 Correct answer:
-Incorrect answer 1:
-Incorrect answer 2:
-Incorrect answer 3:
+Incorrect answer:
+Incorrect answer:
+Incorrect answer:
+
+You will generate {num_questions} questions.
 """,
     PromptType.OPEN_ENDED: """
 You are TeachGPT, a language model trained to help people learn from books they are reading.
@@ -30,6 +34,23 @@ You will generate {num_questions} questions. Use the following template for each
 
 Question:
 Follow-up question:
+""",
+    PromptType.ADD_ANSWERS: """
+You are TeachGPT, a machine learning agent trained to generate educational quizzes. You take in content from a textbook, and create questions about that content that will help students learn more effectively.
+
+TeachGPT follows these rules:
+* Questions should not copy-paste definitions or code from the content. Questions should apply the content to a new situation.
+* Questions should be more than one sentence, and should provide a code snippet or hypothetical situation to ask about.
+* Questions should be multiple-choice with four options.
+
+Questions use the following template:
+Question:
+Correct answer:
+Incorrect answer:
+Incorrect answer:
+Incorrect answer:
+
+You will be given a partially-complete question. Add the remaining answer choices.
 """
 }
 

--- a/lib/quizicist/prompt.py
+++ b/lib/quizicist/prompt.py
@@ -47,18 +47,12 @@ class Prompt:
         self.prompt_type = prompt_type
         self.num_questions = num_questions
 
-
-    def join(self, other: Prompt) -> Prompt:
-        return Prompt(self.prompt + other.prompt, self.num_questions)
-
-
     def add_message(self, role: str, content: str) -> Prompt:
         self.messages.append({
             "role": role,
             "content": content
         })        
         return self
-
 
     def add_system_prompt(self) -> Prompt:
         intro = PROMPTS[self.prompt_type].format(num_questions=self.num_questions)

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -12,4 +12,9 @@ setup(
         "beautifulsoup4==4.11.1",
         "lxml==4.9.1",
     ],
+    extras_require={
+        "dev": [
+            "pytest==7.2.2"
+        ]
+    }
 )

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.1",
     packages=["quizicist"],
     install_requires=[
-        "openai==0.23.0", 
+        "openai==0.27.2", 
         "python-dotenv==0.21.0", 
         "mistletoe==0.9.0",
         "transformers==4.22.1",

--- a/lib/tests/test_prompt.py
+++ b/lib/tests/test_prompt.py
@@ -1,0 +1,8 @@
+from quizicist.prompt import Prompt, PromptType
+
+def test_prompt():
+    for prompt_type in [PromptType.MCQ, PromptType.OPEN_ENDED]:
+        prompt = Prompt(prompt_type=prompt_type)
+        prompt.add_system_prompt()
+        prompt.add_message(role="user", content="hello world")
+        assert len(prompt.messages) == 2


### PR DESCRIPTION
This PR does a few things:
1. It changes from the `Completion` to `ChatCompletion` API to take advantage of GPT-4 and the new "System Prompt" setup.
2. It adds the concept of a `PromptType` so we can generate multiple kinds of questions, e.g. I'm playing around with open-ended questions for my epub experiment.
3. It adds support for pytest unit tests, updating CI accordingly.